### PR TITLE
Add test for Lazy Evaluation of Boolean Operators

### DIFF
--- a/lazyeval/driver.cpp
+++ b/lazyeval/driver.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <cstdio>
+
+// clang++ driver.cpp addition.ll -o add
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+extern "C" {
+    int lazyeval_and(int control);
+    int lazyeval_or(int control);
+}
+
+int main() {
+
+    int and_true = lazyeval_and(1);
+    int and_false = lazyeval_and(0);
+
+    int or_true = lazyeval_or(1);
+    int or_false = lazyeval_or(0);
+
+    if(and_true == 1)
+      std::cout << "PASSED lazy_and when LHS is true Result: " << and_true << std::endl;
+  	else
+  	  std::cout << "FALIED lazy_and when LHS is true Result: " << and_true << std::endl;
+
+    if(and_false == 0)
+      std::cout << "PASSED lazy_and when LHS is false Result: " << and_false << std::endl;
+  	else
+  	  std::cout << "FALIED lazy_and when LHS is false Result: " << and_false << std::endl;
+    
+    if(or_true == 0)
+      std::cout << "PASSED lazy_or when LHS is true Result: " << or_true << std::endl;
+  	else
+  	  std::cout << "FALIED lazy_or when LHS is true Result: " << or_true << std::endl;
+
+    if(or_false == 1)
+      std::cout << "PASSED lazy_or when LHS is false Result: " << or_false << std::endl;
+  	else
+  	  std::cout << "FALIED lazy_or when LHS is false Result: " << or_false << std::endl;
+}

--- a/lazyeval/lazyeval.c
+++ b/lazyeval/lazyeval.c
@@ -1,0 +1,28 @@
+int mutable_var;
+
+int mutating_function(void) {
+    mutable_var = mutable_var + 1;
+    return 1;
+}
+
+// If control == 1 then mutating_function should be run and mutable_var = 1
+// If control != 1 then mutating_function should not be run and mutable_var = 0
+int lazyeval_and(int control) {
+    mutable_var = 0;
+    if (control == 1 && mutating_function()) {
+        return mutable_var;
+    } else {
+        return mutable_var;
+    }
+}
+
+// If control == 1 then mutating_function should not be run and mutable_var = 0
+// If control != 1 then mutating_function should be run and mutable_var = 1
+int lazyeval_or(int control) {
+    mutable_var = 0;
+    if (control == 1 || mutating_function()) {
+        return mutable_var;
+    } else {
+        return mutable_var;
+    }
+}

--- a/tests.sh
+++ b/tests.sh
@@ -64,3 +64,10 @@ rm -rf output.ll global
 "$COMP" ./global.c
 $CLANG driver.cpp output.ll  -o global
 validate "./global"
+
+cd ../lazyeval/
+pwd
+rm -rf output.ll global
+"$COMP" ./lazyeval.c
+$CLANG driver.cpp output.ll  -o lazyeval
+validate "./lazyeval"

--- a/tests.sh
+++ b/tests.sh
@@ -67,7 +67,7 @@ validate "./global"
 
 cd ../lazyeval/
 pwd
-rm -rf output.ll global
+rm -rf output.ll lazyeval
 "$COMP" ./lazyeval.c
-$CLANG driver.cpp output.ll  -o lazyeval
+$CLANG driver.cpp output.ll -o lazyeval
 validate "./lazyeval"


### PR DESCRIPTION
Quick test to check if `||` and `&&` are evaluated lazily. Doesn't currently check if you select the right block as a result of that lazy evaluation though 😐